### PR TITLE
Timezone instructions for proper importing

### DIFF
--- a/GCAL_README.md
+++ b/GCAL_README.md
@@ -8,6 +8,8 @@ Step 1: First, go into Gcal and click the dropdown arrow next to "My Calendar" a
 
 Step 2: Now that you have a calendar set up, you can import your csv into it (without polluting your primary calendar). Click on the dropdown arrow next to "Other calendars" and click "Import calendar."
 
+*Note*: If this year's event is in a timezone different than your usual calendar, set your newly created calendar to the timezone for the event location so that the schedule slots gets imported to the right time slot. Go to Calendar Settings > Calendar Time Zones to view and change timezone settings.
+
 ![](screenshots/step2.png)
 
 Step 3: On the modal window, it will ask you to choose the file you want to use. Download [nicar16sched.csv](https://raw.githubusercontent.com/tommeagher/irescraper/master/GCAL_nicar2016sched.csv) to your local machine, then add it with the chooser.


### PR DESCRIPTION
Added a note for new calendar timezone to be set properly (or at least checked) for the NICAR location so that importing assigns sessions to the correct time slot.
